### PR TITLE
Fix bison homebrew name

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ sudo apt-get install curl build-essential autoconf libjpeg-dev libpng12-dev open
 In order to compile PHP on macOS machines, you must install some brew packages first:
 
 ```
-brew install freetype homebrew/versions/bison27 gettext icu4c jpeg libpng openssl readline homebrew/dupes/zlib
+brew install freetype bison@2.7 gettext icu4c jpeg libpng openssl readline homebrew/dupes/zlib
 ```
 
 and, in order to compile 5.x versions of PHP, you **must** link `bison27` package:
 
 ```
-brew link --force bison27
+brew link --force bison@2.7
 ```
 
 ## Development

--- a/bin/install
+++ b/bin/install
@@ -80,7 +80,7 @@ os_based_configure_options() {
     exit_if_homebrew_not_installed
 
     local freetype_path=$(homebrew_package_path freetype)
-    local bison27_path=$(homebrew_package_path bison27)
+    local bison27_path=$(homebrew_package_path bison@2.7)
     local gettext_path=$(homebrew_package_path gettext)
     local icu4c_path=$(homebrew_package_path icu4c)
     local jpeg_path=$(homebrew_package_path jpeg)


### PR DESCRIPTION
This just changes `bison27` to `bison@2.7`

home-brew seems to prefer the <package>@<version> syntax for specifying versions nowadays.

What do you think?