### PR TITLE
Update documentation for osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,14 @@ language: c
 script: asdf plugin-test php https://github.com/odarriba/asdf-php.git
 before_install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install freetype bison bison27 gettext
-  icu4c jpeg libiconv libpng openssl readline homebrew/dupes/zlib curl; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated jpeg || brew upgrade jpeg; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated openssl || brew upgrade openssl; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated readline || brew upgrade readline; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install freetype bison bison27 gettext icu4c libiconv libpng
+  homebrew/dupes/zlib curl; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PKG_CONFIG_PATH='/usr/local/opt/openssl/lib/pkgconfig'; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PHP_CONFIGURE_OPTIONS='--with-iconv=$(brew --prefix libiconv) --with-openssl=$(brew --prefix openssl)'; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH='/usr/local/opt/icu4c/bin:/usr/local/opt/icu4c/sbin:/usr/local/opt/bison/bin:$PATH'; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="/usr/local/opt/icu4c/bin:/usr/local/opt/icu4c/sbin:/usr/local/opt/bison/bin:$PATH"; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install curl build-essential
   autoconf libjpeg-dev libpng12-dev openssl libssl-dev libcurl4-openssl-dev pkg-config

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ language: c
 script: asdf plugin-test php https://github.com/odarriba/asdf-php.git
 before_install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install freetype bison27 gettext
-  icu4c jpeg libpng openssl readline homebrew/dupes/zlib curl; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew link --force bison27; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew link --force icu4c; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PHP_CONFIGURE_OPTIONS='--disable-gettext'; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install freetype bison bison27 gettext
+  icu4c jpeg libiconv libpng openssl readline homebrew/dupes/zlib curl; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PHP_CONFIGURE_OPTIONS='--with-iconv=$(brew --prefix libiconv) --with-openssl=$(brew --prefix openssl)'; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH='/usr/local/opt/icu4c/bin:/usr/local/opt/icu4c/sbin:/usr/local/opt/bison/bin:$PATH'; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install curl build-essential
   autoconf libjpeg-dev libpng12-dev openssl libssl-dev libcurl4-openssl-dev pkg-config

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   homebrew/dupes/zlib curl; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PKG_CONFIG_PATH='/usr/local/opt/openssl/lib/pkgconfig'; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PHP_CONFIGURE_OPTIONS='--with-iconv=$(brew --prefix libiconv) --with-openssl=$(brew --prefix openssl)'; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="/usr/local/opt/icu4c/bin:/usr/local/opt/icu4c/sbin:/usr/local/opt/bison/bin:$PATH"; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="$(brew --prefix bison):$(brew --prefix icu4c)/bin:$(brew --prefix icu4c)/sbin:$PATH"; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install curl build-essential
   autoconf libjpeg-dev libpng12-dev openssl libssl-dev libcurl4-openssl-dev pkg-config

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Use environment variables to instruct autoconf on where to find the libraries yo
 So replace if necessary:
 
 ```
-PATH="/usr/local/opt/icu4c/bin:/usr/local/opt/icu4c/sbin:/usr/local/opt/bison/bin:$PATH" PHP_CONFIGURE_OPTIONS="--with-iconv=$(brew --prefix libiconv) --with-openssl=$(brew --prefix openssl)" asdf install php <version>
+PATH="$(brew --prefix bison):$(brew --prefix icu4c)/bin:$(brew --prefix icu4c)/sbin:$PATH" PHP_CONFIGURE_OPTIONS="--with-iconv=$(brew --prefix libiconv) --with-openssl=$(brew --prefix openssl)" asdf install php <version>
 ```
 
 **Important note**: There seems to be a bug with PHP `configure` file on recent versions (> 7.1.4) when using on OSX environments. As can be seen in [this PR](https://github.com/phpbrew/phpbrew/issues/876#issuecomment-301553990), it's needed to disable gettext at build time to work, and later on impate the module manually.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ sudo apt-get install curl build-essential autoconf libjpeg-dev libpng12-dev open
 In order to compile PHP on macOS machines, you must install some brew packages first:
 
 ```
-brew install freetype bison bison@2.7 gettext icu4c jpeg libiconv libpng openssl readline homebrew/dupes/zlib
+brew install freetype bison bison27 gettext icu4c jpeg libiconv libpng openssl readline homebrew/dupes/zlib
 ```
 
 Use environment variables to instruct autoconf on where to find the libraries you installed using homebrew:

--- a/README.md
+++ b/README.md
@@ -31,15 +31,16 @@ sudo apt-get install curl build-essential autoconf libjpeg-dev libpng12-dev open
 In order to compile PHP on macOS machines, you must install some brew packages first:
 
 ```
-brew install freetype bison@2.7 gettext icu4c jpeg libpng openssl readline homebrew/dupes/zlib
+brew install freetype bison bison@2.7 gettext icu4c jpeg libiconv libpng openssl readline homebrew/dupes/zlib
 ```
 
-and, in order to compile 5.x versions of PHP, you **must** link `bison27` and `icu4c` packages:
+Use environment variables to instruct autoconf on where to find the libraries you installed using homebrew:
 
 ```
-$ brew link --force bison@2.7
-$ brew link --force icu4c
+PATH="/usr/local/opt/icu4c/bin:/usr/local/opt/icu4c/sbin:/usr/local/opt/bison/bin:$PATH" PHP_CONFIGURE_OPTIONS="--with-iconv=$(brew --prefix libiconv) --with-openssl=$(brew --prefix openssl)" asdf install php <version>
 ```
+
+For PHP 5.x, replace `/usr/local/opt/bison/` in the line above with `/usr/local/opt/bison@2.7/`
 
 **Important note**: There seems to be a bug with PHP `configure` file on recent versions (> 7.1.4) when using on OSX environments. As can be seen in [this PR](https://github.com/phpbrew/phpbrew/issues/876#issuecomment-301553990), it's needed to disable gettext at build time to work, and later on impate the module manually.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Check the [asdf](https://github.com/HashNuke/asdf) readme for instructions on ho
 
 Feel free to create an issue or pull request if you find a bug.
 
+Note that the Travis builds for your PR *will* fail: https://github.com/odarriba/asdf-php/pull/4#issuecomment-319123603
+
 ## Issues
 
 ### No available versions shown

--- a/README.md
+++ b/README.md
@@ -34,13 +34,16 @@ In order to compile PHP on macOS machines, you must install some brew packages f
 brew install freetype bison bison27 gettext icu4c jpeg libiconv libpng openssl readline homebrew/dupes/zlib
 ```
 
-Use environment variables to instruct autoconf on where to find the libraries you installed using homebrew:
+Use environment variables to instruct autoconf on where to find the libraries you installed using homebrew. Note that:
+
+* for PHP 5.6, you must use `brew --prefix bison@2.7` in your PATH
+* for PHP 7.x, you must use `brew --prefix bison` in your PATH
+
+So replace if necessary:
 
 ```
 PATH="/usr/local/opt/icu4c/bin:/usr/local/opt/icu4c/sbin:/usr/local/opt/bison/bin:$PATH" PHP_CONFIGURE_OPTIONS="--with-iconv=$(brew --prefix libiconv) --with-openssl=$(brew --prefix openssl)" asdf install php <version>
 ```
-
-For PHP 5.x, replace `/usr/local/opt/bison/` in the line above with `/usr/local/opt/bison@2.7/`
 
 **Important note**: There seems to be a bug with PHP `configure` file on recent versions (> 7.1.4) when using on OSX environments. As can be seen in [this PR](https://github.com/phpbrew/phpbrew/issues/876#issuecomment-301553990), it's needed to disable gettext at build time to work, and later on impate the module manually.
 


### PR DESCRIPTION
- Add bison to brew packages. Nowadays it will install 3.0.x, which we want for PHP7.x.
- Add libiconv to homebrew packages. This is not installed by default in a clean installation.
- Use environment variables instead of force linking.