### PR TITLE
Add Ubuntu 18.04 dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated openssl || brew upgrade openssl; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated readline || brew upgrade readline; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install freetype bison bison27 gettext icu4c libiconv libpng
-  homebrew/dupes/zlib curl; fi
+  zlib curl; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PKG_CONFIG_PATH='/usr/local/opt/openssl/lib/pkgconfig'; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PHP_CONFIGURE_OPTIONS='--with-iconv=$(brew --prefix libiconv) --with-openssl=$(brew --prefix openssl)'; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="$(brew --prefix bison)/bin:$(brew --prefix icu4c)/bin:$(brew --prefix icu4c)/sbin:$PATH"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   zlib curl; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PKG_CONFIG_PATH='/usr/local/opt/openssl/lib/pkgconfig'; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PHP_CONFIGURE_OPTIONS='--with-iconv=$(brew --prefix libiconv) --with-openssl=$(brew --prefix openssl)'; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="$(brew --prefix bison)/bin:$(brew --prefix icu4c)/bin:$(brew --prefix icu4c)/sbin:$PATH"; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="$(brew --prefix bison)/bin:$(brew --prefix icu4c)/bin:$(brew --prefix icu4c)/sbin:$PATH:$(brew --prefix curl)/bin"; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install curl build-essential
   autoconf libjpeg-dev libpng12-dev openssl libssl-dev libcurl4-openssl-dev pkg-config

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ You may need this libraries and packages to be able to compile PHP compiler vers
 sudo apt-get install curl build-essential autoconf libjpeg-dev libpng12-dev openssl libssl-dev libcurl4-openssl-dev pkg-config libsslcommon2-dev libreadline-dev libedit-dev zlib1g-dev libicu-dev libxml2-dev gettext bison libmysqlclient-dev libpq-dev
 ```
 
+#### Ubuntu 18.04
+
+```
+sudo apt install curl build-essential libjpeg-dev libpng-dev openssl libcurl4-openssl-dev pkg-config libedit-dev zlib1g-dev libicu-dev libxml2-dev gettext bison libmysqlclient-dev libpq-dev
+```
+
 ### macOS
 
 In order to compile PHP on macOS machines, you must install some brew packages first:


### PR DESCRIPTION
I've added the list of dependencies I've used to build the latest PHP 7.2.6 on Ubuntu 18.04, maybe can be of any use to someone else.

Plus I've tried to fix the Mac build. I've sorted one problem, but the list-all command is failing, while it works fine on Linux. Unfortunately I cannot debug on Mac :(