### PR TITLE
Feature - Concurrent Builds

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -15,6 +15,7 @@ install_php() {
 
     local source_path=$(get_download_file_path $install_type $version $tmp_download_dir)
     local configure_options="$(construct_configure_options $install_path)"
+    local make_flags="-j$ASDF_CONCURRENCY"
 
     download_source $install_type $version $source_path
 
@@ -32,9 +33,9 @@ install_php() {
         # Build PHP
         ./buildconf --force || exit 1
         ./configure $configure_options || exit 1
-        make || exit 1
-        # make test || exit 1
-        make install || exit 1
+        make "$make_flags" || exit 1
+        # make "$make_flags" test || exit 1
+        make "$make_flags" install || exit 1
     )
 }
 


### PR DESCRIPTION
# Scope

This PR fixes #11 by setting the make `-j` (jobs) flag based on the `ASDF_CONCURRENCY` environment variable.

This `ASDF_CONCURRENCY` was added in asdf-vm/asdf#75, in response to asdf-vm/asdf#57, and was added to the documentation for creating plugins in asdf-vm/asdf#147.


# Effect

This allows the `make` steps (the most time-consuming steps) of the build/install process to better scale depending on the hardware of the target machine.

On my personal rig, it went from a **single** `make` job to using **16**, which greatly reduced the time needed to complete the build/install process:

![Desktop_2019-12-17_01-06-31](https://user-images.githubusercontent.com/742384/70977126-877d9d00-206a-11ea-8bb5-13e77f1979df.png)
