### PR TITLE
Compare signature with latest instead of hardcoded value

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -40,9 +40,10 @@ install_php() {
 
 install_composer() {
     local bin_path=$1/bin
+    local expected_signature="$(wget -q -O - https://composer.github.io/installer.sig)"
 
     $bin_path/php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-    $bin_path/php -r "if (hash_file('sha384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+    $bin_path/php -r "if (hash_file('sha384', 'composer-setup.php') === '${expected_signature}') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
     $bin_path/php composer-setup.php --install-dir=$bin_path --filename=composer
     $bin_path/php -r "unlink('composer-setup.php');"
 }


### PR DESCRIPTION
The hard coded signature is no longer valid for the latest version of the installer script. This change pulls down the latest signature and compares with the downloaded setup script instead of depending on a hardcoded value.